### PR TITLE
Add support for marshalling a list of Rules from CompiledRules

### DIFF
--- a/Libraries/dnYara.Interop/Interops/Constants.cs
+++ b/Libraries/dnYara.Interop/Interops/Constants.cs
@@ -7,6 +7,11 @@
         public const int YR_MAX_THREADS = 32;
         public const int tidx_mask_size = (((YR_MAX_THREADS) + (CHAR_BIT - 1)) / CHAR_BIT);
 
+        // This is a placeholder for the raw struct data of a YR_MUTEX, which is a HANDLE on windows and a pthread_mutex_t.
+        // These have varying sizes, and we don't actually care about the contents, so we block out the size to ensure
+        // bit offsets are maintained.
+        public const int yr_mutex_blob_size = 56;
+
         public const int YR_MAX_LOOP_NESTING  = 4;
         public const int YR_MAX_INCLUDE_DEPTH = 16;
 

--- a/Libraries/dnYara.Interop/Interops/Constants.cs
+++ b/Libraries/dnYara.Interop/Interops/Constants.cs
@@ -28,5 +28,7 @@
         public const int CALLBACK_MSG_SCAN_FINISHED     = 3;
         public const int CALLBACK_MSG_IMPORT_MODULE     = 4;
         public const int CALLBACK_MSG_MODULE_IMPORTED   = 5;
+
+        public const int RULE_GFLAGS_NULL = 0x1000;
     }
 }

--- a/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
+++ b/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
@@ -61,13 +61,13 @@ namespace dnYara.Interop
             }
         }
 
-        public static IEnumerable<YR_RULE> GetRules(IntPtr rulesPtr) => 
+        public static IEnumerable<YR_RULE> GetRules(IntPtr rulesPtr) =>
             EachStructOfTInObjRef<YR_RULE>(rulesPtr, rule => {
                 var result = ObjRefHelper.RuleIsNull(rule);
                 return !result && rule.identifier != IntPtr.Zero;
             });
-        
-        public static IEnumerable<YR_META> GetMetas(IntPtr yrMetasPtr) => 
+
+        public static IEnumerable<YR_META> GetMetas(IntPtr yrMetasPtr) =>
             EachStructOfTInObjRef<YR_META>(yrMetasPtr, meta => meta.type != (int) META_TYPE.META_TYPE_NULL);
 
         public static string GetYRString(IntPtr objRef)

--- a/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
+++ b/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
@@ -68,7 +68,7 @@ namespace dnYara.Interop
             });
         
         public static IEnumerable<YR_META> GetMetas(IntPtr yrMetasPtr) => 
-            EachStructOfTInObjRef<YR_META>(yrMetasPtr, meta => meta.type != 0);
+            EachStructOfTInObjRef<YR_META>(yrMetasPtr, meta => meta.type != (int) META_TYPE.META_TYPE_NULL);
 
         public static string GetYRString(IntPtr objRef)
         {

--- a/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
+++ b/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
@@ -1,48 +1,24 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace dnYara.Interop
 {
     public static class ObjRefHelper
     {
+        private static int POINTER_SIZE = Marshal.SizeOf(IntPtr.Zero);
+
         public static void ForEachYaraStringInObjRef(IntPtr ref_obj, Action<YR_STRING> action)
         {
             YR_STRING yrString;
             for (
                 IntPtr yrStringPtr = ref_obj;
                 CheckYRString(yrStringPtr, out yrString);
-                yrStringPtr += Marshal.SizeOf(yrStringPtr))
+                yrStringPtr += POINTER_SIZE)
             {
                 action(yrString);
             }
-        }
-
-        public static void ForEachYaraMetaInObjRef(IntPtr ref_obj, Action<YR_META> action)
-        {
-            YR_META yrMeta;
-            for (
-                IntPtr yrStringPtr = ref_obj;
-                CheckYRMeta(yrStringPtr, out yrMeta);
-                yrStringPtr += 4)
-            {
-                action(yrMeta);
-            }
-        }
-
-        public static bool CheckYRMeta(IntPtr yrMetasPtr, out YR_META yrMetas)
-        {
-            yrMetas = default;
-
-            if (yrMetasPtr == IntPtr.Zero)
-                return false;
-
-            yrMetas = (YR_META)Marshal.PtrToStructure(yrMetasPtr, typeof(YR_META));
-
-            if (yrMetas.type == 0)
-                return false;
-
-            return true;
         }
 
         public static bool CheckYRString(IntPtr yrStringPtr, out YR_STRING yrString)
@@ -72,16 +48,27 @@ namespace dnYara.Interop
             }
         }
 
-        public static void ForEachStructOfTInObjRef<T>(IntPtr ref_obj, Func<T, bool> validityChecker, Action<T> action) where T: struct {
+        /// walks a variable-sized array of pointers of type T, marshalling and running a custom validation function on each iteration of the pointer
+        /// This is an abstraction around specialized loops like `ForEachYaraMetaInObjRef`
+        public static IEnumerable<T> EachStructOfTInObjRef<T>(IntPtr ref_obj, Func<T, bool> validityChecker) where T: struct {
             T structPtr;
             for (
                 IntPtr structArrayPtr = ref_obj;
                 MarshalAndValidate(structArrayPtr, validityChecker, out structPtr);
-                structArrayPtr += 4)
+                structArrayPtr += Marshal.SizeOf(typeof(T)))
             {
-                action(structPtr);
+                yield return structPtr;
             }
         }
+
+        public static IEnumerable<YR_RULE> GetRules(IntPtr rulesPtr) => 
+            EachStructOfTInObjRef<YR_RULE>(rulesPtr, rule => {
+                var result = ObjRefHelper.RuleIsNull(rule);
+                return !result && rule.identifier != IntPtr.Zero;
+            });
+        
+        public static IEnumerable<YR_META> GetMetas(IntPtr yrMetasPtr) => 
+            EachStructOfTInObjRef<YR_META>(yrMetasPtr, meta => meta.type != 0);
 
         public static string GetYRString(IntPtr objRef)
         {
@@ -126,12 +113,10 @@ namespace dnYara.Interop
         public static bool MarshalAndValidate<T>(IntPtr struct_ptr, Func<T, bool> validityChecker, out T destination_ptr) where T : struct {
             destination_ptr = default(T);
             if (struct_ptr == IntPtr.Zero) {
-                Console.WriteLine($"can't marshal a {typeof(T)} from a zero intptr");
                 return false;
             }
 
-            destination_ptr = Marshal.PtrToStructure<T>(struct_ptr);
-            Console.WriteLine($"Marshaled a {typeof(T)}: {destination_ptr}");
+            destination_ptr = (T)Marshal.PtrToStructure(struct_ptr, typeof(T));
             return validityChecker(destination_ptr);
         }
 
@@ -155,9 +140,7 @@ namespace dnYara.Interop
         // replicates the RULE_IS_NULL check from the types.h module of yara.
         // used in rule iteration.
         public static bool RuleIsNull(YR_RULE rule) {
-            var flags = rule.g_flags & RULE_GFLAGS_NULL;
-            Console.WriteLine($"rule {rule.identifier} with flags {rule.g_flags} (AND-d {flags}) is {flags != 0}");
-            return flags != 0;
+            return (rule.g_flags & RULE_GFLAGS_NULL) != 0;
         }
     }
 }

--- a/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
+++ b/Libraries/dnYara.Interop/Interops/ObjRefHelper.cs
@@ -135,12 +135,10 @@ namespace dnYara.Interop
 
         }
 
-        public static readonly int RULE_GFLAGS_NULL = 0x1000;
-
         // replicates the RULE_IS_NULL check from the types.h module of yara.
         // used in rule iteration.
         public static bool RuleIsNull(YR_RULE rule) {
-            return (rule.g_flags & RULE_GFLAGS_NULL) != 0;
+            return (rule.g_flags & Constants.RULE_GFLAGS_NULL) != 0;
         }
     }
 }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_META.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_META.cs
@@ -4,8 +4,10 @@ using System.Runtime.InteropServices;
 
 namespace dnYara.Interop
 {
+
     /// <summary>
-    /// Data structure representing a metadata value.
+    /// Data structure representing a metadata value. Based on `type`, zero or one of `integerValue` or `stringValue` will be filled,
+    /// and if `type` is `META_TYPE_BOOLEAN` then `integerValue` should be parsed as a boolean
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct YR_META
@@ -17,14 +19,14 @@ namespace dnYara.Interop
         /// </summary>
         public int type;
         
-        public long integer;
+        public long integerValue;
 
         /// <summary>
         /// Meta identifier.
         /// </summary>
         public IntPtr identifier;
         
-        public IntPtr strings;
+        public IntPtr stringValue;
     }
 
 }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_META.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_META.cs
@@ -6,8 +6,8 @@ namespace dnYara.Interop
 {
 
     /// <summary>
-    /// Data structure representing a metadata value. Based on `type`, zero or one of `integerValue` or `stringValue` will be filled,
-    /// and if `type` is `META_TYPE_BOOLEAN` then `integerValue` should be parsed as a boolean
+    /// Data structure representing a metadata value. Based on `type`, zero or one of `integer` or `strings` will be filled,
+    /// and if `type` is `META_TYPE_BOOLEAN` then `integer` should be parsed as a boolean
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct YR_META
@@ -19,14 +19,14 @@ namespace dnYara.Interop
         /// </summary>
         public int type;
         
-        public long integerValue;
+        public long integer;
 
         /// <summary>
         /// Meta identifier.
         /// </summary>
         public IntPtr identifier;
         
-        public IntPtr stringValue;
+        public IntPtr strings;
     }
 
 }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_RULE.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_RULE.cs
@@ -3,48 +3,40 @@ using System.Runtime.InteropServices;
 
 namespace dnYara.Interop
 {
-    [StructLayout(LayoutKind.Explicit, Size = 448)]
-    public unsafe struct YR_RULE
+    [StructLayout(LayoutKind.Sequential)]
+    public struct YR_RULE
     {
         // Global flags
-        [FieldOffset(0)]
         public int g_flags;
 
         // Thread-specific flags
-        [FieldOffset(4)]
-        public fixed int t_flags[32];
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.YR_MAX_THREADS, ArraySubType = UnmanagedType.I4)]
+        public int[] t_flags;
 
-        [FieldOffset(136)]
         public IntPtr identifier;
 
-        [FieldOffset(144)]
         public IntPtr tags;
 
-        [FieldOffset(152)]
         public IntPtr metas;
 
-        [FieldOffset(160)]
         public IntPtr strings;
 
-        [FieldOffset(168)]
         public IntPtr ns;
 
         // Number of atoms generated for this rule.
-        [FieldOffset(176)]
         public int num_atoms;
 
         // Used only when PROFILING_ENABLED is defined. This is the sum of all values
         // in time_cost_per_thread. This is updated once on each call to
         // yr_scanner_scan_xxx.
-        [FieldOffset(184)]
         public long time_cost;
 
         // Used only when PROFILING_ENABLED is defined. This array holds the time
         // cost for each thread using this structure concurrenlty. This is necessary
         // because a global variable causes too much contention while trying to
         // increment in a synchronized way from multiple threads.
-        [FieldOffset(192)]
-        public fixed long time_cost_per_thread[32];
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.YR_MAX_THREADS, ArraySubType = UnmanagedType.I8)]
+        public long[] time_cost_per_thread;
     }
 
 }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_RULE.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_RULE.cs
@@ -3,34 +3,38 @@ using System.Runtime.InteropServices;
 
 namespace dnYara.Interop
 {
-    [StructLayout(LayoutKind.Sequential)]
-    public struct YR_RULE
+    [StructLayout(LayoutKind.Explicit, Size = 448)]
+    public unsafe struct YR_RULE
     {
-        public Int32 g_flags;       // Global flags
-        
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.YR_MAX_THREADS, ArraySubType = UnmanagedType.I4)]
-        public Int32[] t_flags;     // Thread-specific flags
-        
-        public IntPtr identifier;
-        public IntPtr tags;
-        public IntPtr metas;
-        public IntPtr strings;
-        public IntPtr ns;
+        [FieldOffset(0)]
+        public int g_flags;
 
-        // Number of atoms generated for this rule.
-        public Int32 num_atoms;
+        [FieldOffset(4)]
+        public fixed int t_flags[32];
 
-        // Used only when PROFILING_ENABLED is defined. This is the sum of all values
-        // in time_cost_per_thread. This is updated once on each call to
-        // yr_scanner_scan_xxx.
-        public Int64 time_cost;
+        [FieldOffset(136)]
+        public global::System.IntPtr identifier;
 
-        // Used only when PROFILING_ENABLED is defined. This array holds the time
-        // cost for each thread using this structure concurrenlty. This is necessary
-        // because a global variable causes too much contention while trying to
-        // increment in a synchronized way from multiple threads.
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.YR_MAX_THREADS, ArraySubType = UnmanagedType.I8)]
-        public Int64[] time_cost_per_thread;
+        [FieldOffset(144)]
+        public global::System.IntPtr tags;
+
+        [FieldOffset(152)]
+        public global::System.IntPtr metas;
+
+        [FieldOffset(160)]
+        public global::System.IntPtr strings;
+
+        [FieldOffset(168)]
+        public global::System.IntPtr ns;
+
+        [FieldOffset(176)]
+        public int num_atoms;
+
+        [FieldOffset(184)]
+        public long time_cost;
+
+        [FieldOffset(192)]
+        public fixed long time_cost_per_thread[32];
     }
 
 }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_RULE.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_RULE.cs
@@ -6,33 +6,43 @@ namespace dnYara.Interop
     [StructLayout(LayoutKind.Explicit, Size = 448)]
     public unsafe struct YR_RULE
     {
+        // Global flags
         [FieldOffset(0)]
         public int g_flags;
 
+        // Thread-specific flags
         [FieldOffset(4)]
         public fixed int t_flags[32];
 
         [FieldOffset(136)]
-        public global::System.IntPtr identifier;
+        public IntPtr identifier;
 
         [FieldOffset(144)]
-        public global::System.IntPtr tags;
+        public IntPtr tags;
 
         [FieldOffset(152)]
-        public global::System.IntPtr metas;
+        public IntPtr metas;
 
         [FieldOffset(160)]
-        public global::System.IntPtr strings;
+        public IntPtr strings;
 
         [FieldOffset(168)]
-        public global::System.IntPtr ns;
+        public IntPtr ns;
 
+        // Number of atoms generated for this rule.
         [FieldOffset(176)]
         public int num_atoms;
 
+        // Used only when PROFILING_ENABLED is defined. This is the sum of all values
+        // in time_cost_per_thread. This is updated once on each call to
+        // yr_scanner_scan_xxx.
         [FieldOffset(184)]
         public long time_cost;
 
+        // Used only when PROFILING_ENABLED is defined. This array holds the time
+        // cost for each thread using this structure concurrenlty. This is necessary
+        // because a global variable causes too much contention while trying to
+        // increment in a synchronized way from multiple threads.
         [FieldOffset(192)]
         public fixed long time_cost_per_thread[32];
     }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
@@ -4,44 +4,48 @@ using System.Runtime.InteropServices;
 
 namespace dnYara.Interop
 {
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-    public struct YR_RULES
+    [StructLayout(LayoutKind.Explicit, Size = 64)]
+    public unsafe struct OpaquePthreadMutexT
     {
+        [FieldOffset(0)]
+        public long __sig;
 
-        /// unsigned char[4]
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.tidx_mask_size, ArraySubType = UnmanagedType.I1)]
-        public char[] tidx_mask;
+        [FieldOffset(8)]
+        public fixed sbyte __opaque[56];
+    }
 
-        /// uint8_t*
-        public IntPtr code_start;
+    [StructLayout(LayoutKind.Explicit, Size = 136)]
+    public unsafe struct YR_RULES
+    {   
+        [FieldOffset(0)]
+        public fixed byte tidx_mask[4];
 
-        /// the sizeof the YR_MUTEX struct is either sizeof HANDLE (32/64 bits on windows), or sizeof pthread_mutex_t (40 bits on nix)
-        /// so this block of bytes needs to be that long to ensure the other field offsets are correct
-        /// YR_MUTEX->HANDLE->void*
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 64, ArraySubType = UnmanagedType.I1)]
-        public byte[] mutex;
+        [FieldOffset(8)]
+        public global::System.IntPtr code_start;
 
-        /// YR_ARENA*
-        public IntPtr arena;
+        [FieldOffset(16)]
+        public OpaquePthreadMutexT mutex;
 
-        /// YR_RULE*
-        public IntPtr rules_list_head;
+        [FieldOffset(80)]
+        public global::System.IntPtr arena;
 
-        /// YR_EXTERNAL_VARIABLE*
-        public IntPtr externals_list_head;
+        [FieldOffset(88)]
+        public global::System.IntPtr rules_list_head;
 
-        /// YR_AC_TRANSITION_TABLE->YR_AC_TRANSITION*
-        public IntPtr ac_transition_table;
+        [FieldOffset(96)]
+        public global::System.IntPtr externals_list_head;
 
-        /// YR_AC_MATCH_TABLE->YR_AC_MATCH_TABLE_ENTRY*
-        public IntPtr ac_match_table;
+        [FieldOffset(104)]
+        public global::System.IntPtr ac_transition_table;
 
-        // Size of ac_match_table and ac_transition_table in number of items (both
-        // tables have the same numbe of items).
-        public UInt32 ac_tables_size;
+        [FieldOffset(112)]
+        public global::System.IntPtr ac_match_table;
 
-        // Used only when PROFILING_ENABLED is defined.
-        public UInt64 time_cost;
+        [FieldOffset(120)]
+        public uint ac_tables_size;
+
+        [FieldOffset(128)]
+        public ulong time_cost;
     }
 
 }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
@@ -15,8 +15,11 @@ namespace dnYara.Interop
         /// uint8_t*
         public IntPtr code_start;
 
+        /// the sizeof the YR_MUTEX struct is either sizeof HANDLE (32/64 bits on windows), or sizeof pthread_mutex_t (40 bits on nix)
+        /// so this block of bytes needs to be that long to ensure the other field offsets are correct
         /// YR_MUTEX->HANDLE->void*
-        public IntPtr mutex;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 64, ArraySubType = UnmanagedType.I1)]
+        public byte[] mutex;
 
         /// YR_ARENA*
         public IntPtr arena;

--- a/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
@@ -16,34 +16,45 @@ namespace dnYara.Interop
 
     [StructLayout(LayoutKind.Explicit, Size = 136)]
     public unsafe struct YR_RULES
-    {   
+    {
+        /// unsigned char[4]
         [FieldOffset(0)]
         public fixed byte tidx_mask[4];
 
+        /// uint8_t*
         [FieldOffset(8)]
-        public global::System.IntPtr code_start;
+        public IntPtr code_start;
 
+        /// YR_MUTEX->(HANDLE->void* or pthread_mutex_t)
         [FieldOffset(16)]
         public OpaquePthreadMutexT mutex;
 
+        /// YR_ARENA*
         [FieldOffset(80)]
-        public global::System.IntPtr arena;
+        public IntPtr arena;
 
+        /// YR_RULE*
         [FieldOffset(88)]
-        public global::System.IntPtr rules_list_head;
+        public IntPtr rules_list_head;
 
+        /// YR_EXTERNAL_VARIABLE*
         [FieldOffset(96)]
-        public global::System.IntPtr externals_list_head;
+        public IntPtr externals_list_head;
 
+        /// YR_AC_TRANSITION_TABLE->YR_AC_TRANSITION*
         [FieldOffset(104)]
-        public global::System.IntPtr ac_transition_table;
+        public IntPtr ac_transition_table;
 
+        /// YR_AC_MATCH_TABLE->YR_AC_MATCH_TABLE_ENTRY*
         [FieldOffset(112)]
-        public global::System.IntPtr ac_match_table;
+        public IntPtr ac_match_table;
 
+        // Size of ac_match_table and ac_transition_table in number of items (both
+        // tables have the same numbe of items).
         [FieldOffset(120)]
         public uint ac_tables_size;
 
+        // Used only when PROFILING_ENABLED is defined.
         [FieldOffset(128)]
         public ulong time_cost;
     }

--- a/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
+++ b/Libraries/dnYara.Interop/Interops/Types/YR_RULES.cs
@@ -4,58 +4,48 @@ using System.Runtime.InteropServices;
 
 namespace dnYara.Interop
 {
-    [StructLayout(LayoutKind.Explicit, Size = 64)]
-    public unsafe struct OpaquePthreadMutexT
+    [StructLayout(LayoutKind.Sequential)]
+    public struct OpaquePthreadMutexT
     {
-        [FieldOffset(0)]
         public long __sig;
 
-        [FieldOffset(8)]
-        public fixed sbyte __opaque[56];
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.yr_mutex_blob_size, ArraySubType = UnmanagedType.I1)]
+        public sbyte[] __opaque;
     }
 
-    [StructLayout(LayoutKind.Explicit, Size = 136)]
-    public unsafe struct YR_RULES
+    [StructLayout(LayoutKind.Sequential)]
+    public struct YR_RULES
     {
         /// unsigned char[4]
-        [FieldOffset(0)]
-        public fixed byte tidx_mask[4];
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.tidx_mask_size, ArraySubType = UnmanagedType.I1)]
+        public byte[] tidx_mask;
 
         /// uint8_t*
-        [FieldOffset(8)]
         public IntPtr code_start;
 
         /// YR_MUTEX->(HANDLE->void* or pthread_mutex_t)
-        [FieldOffset(16)]
         public OpaquePthreadMutexT mutex;
 
         /// YR_ARENA*
-        [FieldOffset(80)]
         public IntPtr arena;
 
         /// YR_RULE*
-        [FieldOffset(88)]
         public IntPtr rules_list_head;
 
         /// YR_EXTERNAL_VARIABLE*
-        [FieldOffset(96)]
         public IntPtr externals_list_head;
 
         /// YR_AC_TRANSITION_TABLE->YR_AC_TRANSITION*
-        [FieldOffset(104)]
         public IntPtr ac_transition_table;
 
         /// YR_AC_MATCH_TABLE->YR_AC_MATCH_TABLE_ENTRY*
-        [FieldOffset(112)]
         public IntPtr ac_match_table;
 
         // Size of ac_match_table and ac_transition_table in number of items (both
         // tables have the same numbe of items).
-        [FieldOffset(120)]
         public uint ac_tables_size;
 
         // Used only when PROFILING_ENABLED is defined.
-        [FieldOffset(128)]
         public ulong time_cost;
     }
 

--- a/Libraries/dnYara.Interop/dnYara.Interop.csproj
+++ b/Libraries/dnYara.Interop/dnYara.Interop.csproj
@@ -9,7 +9,6 @@
     <Company>Airbus CERT</Company>
     <Authors>Sylvain B. for Airbus CERT</Authors>
     <Copyright>Airbus CERT</Copyright>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RepositoryUrl>https://github.com/airbus-cert/dnYara</RepositoryUrl>
     <PackageProjectUrl>https://github.com/airbus-cert/dnYara</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Libraries/dnYara.Interop/dnYara.Interop.csproj
+++ b/Libraries/dnYara.Interop/dnYara.Interop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>1.0.3.2</Version>

--- a/Libraries/dnYara.Interop/dnYara.Interop.csproj
+++ b/Libraries/dnYara.Interop/dnYara.Interop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>1.0.3.2</Version>
@@ -9,6 +9,7 @@
     <Company>Airbus CERT</Company>
     <Authors>Sylvain B. for Airbus CERT</Authors>
     <Copyright>Airbus CERT</Copyright>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RepositoryUrl>https://github.com/airbus-cert/dnYara</RepositoryUrl>
     <PackageProjectUrl>https://github.com/airbus-cert/dnYara</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/UnitTests/dnYara.UnitTests/ScanTests.cs
+++ b/UnitTests/dnYara.UnitTests/ScanTests.cs
@@ -129,6 +129,17 @@ namespace dnYara.UnitTests
         [Fact]
         public void CheckIterateRulesTest()
         {
+            string ruleText = @"rule foo: bar {
+                meta:
+                    bool_meta = true
+                    int_meta = 10
+                    string_meta = ""what a long, drawn-out thing this is!""
+                strings:
+                    $a = ""nml""
+                condition:
+                    $a
+                }";
+
             // Initialize yara context
             using (YaraContext ctx = new YaraContext())
             {
@@ -137,18 +148,21 @@ namespace dnYara.UnitTests
 
                 using (var compiler = new Compiler())
                 {
-                    compiler.AddRuleString("rule foo: bar {strings: $a = \"nml\" condition: $a}");
+                    compiler.AddRuleString(ruleText);
 
                     rules = compiler.Compile();
                 }
                 System.Threading.Thread.Sleep(2000);
 
                 if (rules != null)
-                {   
+                {
                     var rule = rules.Rules.ToList()[0];
                     Assert.NotEmpty(rules.Rules);
                     Assert.Equal("foo", rule.Identifier);
                     Assert.Equal("bar", rule.Tags[0]);
+                    Assert.Equal(true, rule.Metas["bool_meta"]);
+                    Assert.Equal((long)10, rule.Metas["int_meta"]);
+                    Assert.Equal("what a long, drawn-out thing this is!", rule.Metas["string_meta"]);
                 }
             }
         }

--- a/UnitTests/dnYara.UnitTests/ScanTests.cs
+++ b/UnitTests/dnYara.UnitTests/ScanTests.cs
@@ -124,5 +124,40 @@ namespace dnYara.UnitTests
                 }
             }
         }
+
+        [Fact]
+        public void CheckIterateRulesTest()
+        {
+            // Initialize yara context
+            using (YaraContext ctx = new YaraContext())
+            {
+                // Compile yara rules
+                CompiledRules rules = null;
+
+                using (var compiler = new Compiler())
+                {
+                    compiler.AddRuleString("rule foo: bar {strings: $a = \"nml\" condition: $a}");
+
+                    rules = compiler.Compile();
+                }
+                System.Threading.Thread.Sleep(2000);
+
+                if (rules != null)
+                {
+                    Assert.NotEmpty(rules.Rules);
+                    var rule = rules.Rules[0];
+                    System.Console.WriteLine($"rule {rule.Identifier}, tags: {rule.Tags}");
+                    Assert.Equal("foo", rule.Identifier);
+                    Assert.Equal("bar", rule.Tags[0]);
+                }
+            }
+        }
+    }
+    class Program {
+        static void Main(string[] args) {
+            System.Console.WriteLine("HEllo");
+            new ScanTests().CheckIterateRulesTest();
+        }
     }
 }
+

--- a/UnitTests/dnYara.UnitTests/ScanTests.cs
+++ b/UnitTests/dnYara.UnitTests/ScanTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 using Xunit;
 
 namespace dnYara.UnitTests
@@ -143,20 +144,13 @@ namespace dnYara.UnitTests
                 System.Threading.Thread.Sleep(2000);
 
                 if (rules != null)
-                {
+                {   
+                    var rule = rules.Rules.ToList()[0];
                     Assert.NotEmpty(rules.Rules);
-                    var rule = rules.Rules[0];
-                    System.Console.WriteLine($"rule {rule.Identifier}, tags: {rule.Tags}");
                     Assert.Equal("foo", rule.Identifier);
                     Assert.Equal("bar", rule.Tags[0]);
                 }
             }
-        }
-    }
-    class Program {
-        static void Main(string[] args) {
-            System.Console.WriteLine("HEllo");
-            new ScanTests().CheckIterateRulesTest();
         }
     }
 }

--- a/UnitTests/dnYara.UnitTests/ScanTests.cs
+++ b/UnitTests/dnYara.UnitTests/ScanTests.cs
@@ -152,7 +152,6 @@ namespace dnYara.UnitTests
 
                     rules = compiler.Compile();
                 }
-                System.Threading.Thread.Sleep(2000);
 
                 if (rules != null)
                 {

--- a/UnitTests/dnYara.UnitTests/dnYara.UnitTests.csproj
+++ b/UnitTests/dnYara.UnitTests/dnYara.UnitTests.csproj
@@ -2,13 +2,12 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" /> -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
-    <!-- <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" /> -->
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/dnYara.UnitTests/dnYara.UnitTests.csproj
+++ b/UnitTests/dnYara.UnitTests/dnYara.UnitTests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <!-- <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" /> -->
     <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <!-- <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" /> -->
   </ItemGroup>
 
   <ItemGroup>

--- a/dnYara/CompiledRules.cs
+++ b/dnYara/CompiledRules.cs
@@ -9,20 +9,18 @@ namespace dnYara
     /// <summary>
     /// Yara compiled rules.
     /// </summary>
-    public sealed class CompiledRules 
+    public sealed class CompiledRules
         : IDisposable
     {
         internal IntPtr BasePtr { get; set; }
-        private YR_RULES _struct = default(YR_RULES);
-        
+
         public List<Rule> Rules { get; private set; }
 
         public CompiledRules(IntPtr rulesPtr)
         {
             BasePtr = rulesPtr;
-            _struct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
-            
-            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule)).ToList();
+            var ruleStruct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
+            Rules = ObjRefHelper.GetRules(ruleStruct.rules_list_head).Select(rule => new Rule(rule)).ToList();
         }
 
         public CompiledRules(string filename)
@@ -30,18 +28,13 @@ namespace dnYara
             IntPtr ptr = IntPtr.Zero;
             ErrorUtility.ThrowOnError(Methods.yr_rules_load(filename, ref ptr));
             BasePtr = ptr;
-            _struct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
-            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule)).ToList();
+            var ruleStruct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
+            Rules = ObjRefHelper.GetRules(ruleStruct.rules_list_head).Select(rule => new Rule(rule)).ToList();
         }
 
         ~CompiledRules()
         {
             Dispose();
-        }
-
-        public YR_RULES GetStruct()
-        {
-            return _struct;
         }
 
         public bool Save(string filename)
@@ -59,7 +52,7 @@ namespace dnYara
                 Methods.yr_rules_destroy(ptr);
             }
         }
-        
+
         public IntPtr Release()
         {
             var temp = BasePtr;

--- a/dnYara/CompiledRules.cs
+++ b/dnYara/CompiledRules.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using dnYara.Interop;
 
@@ -14,28 +15,14 @@ namespace dnYara
         internal IntPtr BasePtr { get; set; }
         private YR_RULES _struct = default(YR_RULES);
         
-        public List<Rule> Rules { get; private set; }
+        public IEnumerable<Rule> Rules { get; private set; }
 
         public CompiledRules(IntPtr rulesPtr)
         {
             BasePtr = rulesPtr;
             _struct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
-            Rules = new List<Rule>();
-            Console.WriteLine($"Marshalled YR_RULES struct, cost {_struct.time_cost}");
-            ObjRefHelper.ForEachStructOfTInObjRef<YR_RULE>(
-                _struct.rules_list_head, 
-                rule => {
-                    Console.WriteLine($"Checking rule {rule.identifier} with flags {rule.g_flags}");
-                    var result = ObjRefHelper.RuleIsNull(rule);
-                    Console.WriteLine($"Rule {rule.identifier} is null: {result}");
-                    return !result;
-                },
-                rule => {
-                    Console.WriteLine($"Creating new Rule for {rule.identifier}");
-                    var created = new Rule(rule);
-                    Console.WriteLine($"Created new rule {created.Identifier}");
-                    Rules.Add(created);
-                });
+            
+            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule));
         }
 
         public CompiledRules(string filename)
@@ -44,21 +31,7 @@ namespace dnYara
             ErrorUtility.ThrowOnError(Methods.yr_rules_load(filename, ref ptr));
             BasePtr = ptr;
             _struct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
-            Rules = new List<Rule>();
-            ObjRefHelper.ForEachStructOfTInObjRef<YR_RULE>(
-                _struct.rules_list_head, 
-                rule => {
-                    Console.WriteLine($"Checking rule {rule.identifier} with flags {rule.g_flags}");
-                    var result = ObjRefHelper.RuleIsNull(rule);
-                    Console.WriteLine($"Rule {rule.identifier} is null: {result}");
-                    return !result;
-                },
-                rule => {
-                    Console.WriteLine($"Creating new Rule for {rule.identifier}");
-                    var created = new Rule(rule);
-                    Console.WriteLine($"Created new rule {created.Identifier}");
-                    Rules.Add(created);
-                });
+            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule));
         }
 
         ~CompiledRules()

--- a/dnYara/CompiledRules.cs
+++ b/dnYara/CompiledRules.cs
@@ -15,14 +15,14 @@ namespace dnYara
         internal IntPtr BasePtr { get; set; }
         private YR_RULES _struct = default(YR_RULES);
         
-        public IEnumerable<Rule> Rules { get; private set; }
+        public List<Rule> Rules { get; private set; }
 
         public CompiledRules(IntPtr rulesPtr)
         {
             BasePtr = rulesPtr;
             _struct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
             
-            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule));
+            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule)).ToList();
         }
 
         public CompiledRules(string filename)
@@ -31,7 +31,7 @@ namespace dnYara
             ErrorUtility.ThrowOnError(Methods.yr_rules_load(filename, ref ptr));
             BasePtr = ptr;
             _struct = Marshal.PtrToStructure<YR_RULES>(BasePtr);
-            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule));
+            Rules = ObjRefHelper.GetRules(_struct.rules_list_head).Select(rule => new Rule(rule)).ToList();
         }
 
         ~CompiledRules()

--- a/dnYara/Rule.cs
+++ b/dnYara/Rule.cs
@@ -11,8 +11,6 @@ namespace dnYara
     /// </summary>
     public sealed class Rule
     {
-        private Nullable<YR_RULE> _struct;
-
         /// <summary>
         /// Rule identifier.
         /// </summary>
@@ -36,7 +34,7 @@ namespace dnYara
         /// </summary>
         public IDictionary<string, object>  Metas { get; private set; }
 
-        public long TimeCost => _struct.HasValue ? _struct.Value.time_cost : 0;
+        public long TimeCost { get; private set; }
 
         public Rule()
         {
@@ -66,13 +64,12 @@ namespace dnYara
 
         public Rule(YR_RULE rule)
         {
-            _struct = rule;
-            IntPtr ptr = _struct.Value.identifier;
+            IntPtr ptr = rule.identifier;
             Identifier = Marshal.PtrToStringAnsi(ptr);
             Tags = new List<string>();
-            ObjRefHelper.ForEachStringInObjRef(_struct.Value.tags, Tags.Add);
-            Metas = ObjRefHelper.GetMetas(_struct.Value.metas).Select(ExtractMetaValue).ToDictionary();
-
+            ObjRefHelper.ForEachStringInObjRef(rule.tags, Tags.Add);
+            Metas = ObjRefHelper.GetMetas(rule.metas).Select(ExtractMetaValue).ToDictionary();
+            TimeCost = rule.time_cost;
         }
     }
 }

--- a/dnYara/Rule.cs
+++ b/dnYara/Rule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Linq;
 using dnYara.Interop;
 
 namespace dnYara
@@ -21,22 +22,52 @@ namespace dnYara
         /// To iterate over the tags you can use yr_rule_tags_foreach().
         /// </summary>
         public List<string> Tags { get; set; }
-        
+
+        /// <summary>
+        /// Key-Value pairs associated with the rule. The value portion can be one of
+        /// <list type="bullet">
+        /// <term>string</term>
+        /// <term>long (int64)</term>
+        /// <term>boolean</term>
+        /// <term>null</term>
+        /// </list>
+        /// </summary>
+        public IDictionary<string, object>  Metas { get; private set; }
+
         public Rule()
         {
             Identifier = string.Empty;
             Tags = new List<string>();
+            Metas = new Dictionary<string, object>();
         }
 
+        private static (string name, object value) ExtractMetaValue (YR_META meta) {
+            var name = Marshal.PtrToStringAnsi(meta.identifier);
+            object v = null;
+            switch((META_TYPE)meta.type) {
+                case META_TYPE.META_TYPE_NULL:
+                    break;
+                case META_TYPE.META_TYPE_INTEGER:
+                    v = meta.integerValue;
+                    break;
+                case META_TYPE.META_TYPE_BOOLEAN:
+                    v = meta.integerValue == 0 ? false : true;
+                    break;
+                case META_TYPE.META_TYPE_STRING:
+                    v = Marshal.PtrToStringAnsi(meta.stringValue);
+                    break;
+            }
+            return (name, v);
+        }
 
         public Rule(YR_RULE rule)
         {
             IntPtr ptr = rule.identifier;
             Identifier = Marshal.PtrToStringAnsi(ptr);
-
             Tags = new List<string>();
-            
             ObjRefHelper.ForEachStringInObjRef(rule.tags, Tags.Add);
+            Metas = ObjRefHelper.GetMetas(rule.metas).Select(ExtractMetaValue).ToDictionary();
+
         }
     }
 }

--- a/dnYara/Rule.cs
+++ b/dnYara/Rule.cs
@@ -11,6 +11,8 @@ namespace dnYara
     /// </summary>
     public sealed class Rule
     {
+        private Nullable<YR_RULE> _struct;
+
         /// <summary>
         /// Rule identifier.
         /// </summary>
@@ -34,6 +36,8 @@ namespace dnYara
         /// </summary>
         public IDictionary<string, object>  Metas { get; private set; }
 
+        public long TimeCost => _struct.HasValue ? _struct.Value.time_cost : 0;
+
         public Rule()
         {
             Identifier = string.Empty;
@@ -48,13 +52,13 @@ namespace dnYara
                 case META_TYPE.META_TYPE_NULL:
                     break;
                 case META_TYPE.META_TYPE_INTEGER:
-                    v = meta.integerValue;
+                    v = meta.integer;
                     break;
                 case META_TYPE.META_TYPE_BOOLEAN:
-                    v = meta.integerValue == 0 ? false : true;
+                    v = meta.integer == 0 ? false : true;
                     break;
                 case META_TYPE.META_TYPE_STRING:
-                    v = Marshal.PtrToStringAnsi(meta.stringValue);
+                    v = Marshal.PtrToStringAnsi(meta.strings);
                     break;
             }
             return (name, v);
@@ -62,11 +66,12 @@ namespace dnYara
 
         public Rule(YR_RULE rule)
         {
-            IntPtr ptr = rule.identifier;
+            _struct = rule;
+            IntPtr ptr = _struct.Value.identifier;
             Identifier = Marshal.PtrToStringAnsi(ptr);
             Tags = new List<string>();
-            ObjRefHelper.ForEachStringInObjRef(rule.tags, Tags.Add);
-            Metas = ObjRefHelper.GetMetas(rule.metas).Select(ExtractMetaValue).ToDictionary();
+            ObjRefHelper.ForEachStringInObjRef(_struct.Value.tags, Tags.Add);
+            Metas = ObjRefHelper.GetMetas(_struct.Value.metas).Select(ExtractMetaValue).ToDictionary();
 
         }
     }

--- a/dnYara/Util.cs
+++ b/dnYara/Util.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace dnYara {
+    public static class DictionaryExtensions {
+        public static IDictionary<Key, Value> ToDictionary<Key, Value>(this IEnumerable<(Key,Value)> values) {
+            var dict = new Dictionary<Key, Value>();
+            foreach (var (key, value) in values) {
+                dict[key] = value;
+            }
+            return dict;
+        } 
+    }
+}


### PR DESCRIPTION
This got a bit larger than I anticipated, but I was attempting to use this library to parse, validate and tests rules as part of a GUI application and found that I couldn't do that easily (thanks, C header macros!).  This was in part because the definitions for YR_RULE and YR_RULES didn't have the correct alignment for some of the fields. I used `CppSharp` to generate a version of what those offsets should be and then used the offsets it provided, which were great!  I was able to plumb through support for Rules, Metas, and simple time_cost fields with a little effort, and I added a test to show that they all work.
