### PR TITLE
Added a CustomScanner to wrap yr_scanner routines

### DIFF
--- a/Libraries/dnYara.Interop/Interops/Methods.cs
+++ b/Libraries/dnYara.Interop/Interops/Methods.cs
@@ -36,9 +36,9 @@ namespace dnYara.Interop
         ///user_data: void*
         [DllImport(YaraLibName, EntryPoint = "_yr_compiler_default_include_callback")]
         public static extern IntPtr _yr_compiler_default_include_callback(
-            [In, MarshalAs(UnmanagedType.LPStr)] string include_name, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string calling_rule_filename, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string calling_rule_namespace, 
+            [In, MarshalAs(UnmanagedType.LPStr)] string include_name,
+            [In, MarshalAs(UnmanagedType.LPStr)] string calling_rule_filename,
+            [In, MarshalAs(UnmanagedType.LPStr)] string calling_rule_namespace,
             IntPtr user_data);
 
 
@@ -60,8 +60,8 @@ namespace dnYara.Interop
         ///user_data: void*
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_set_callback")]
         public static extern void yr_compiler_set_callback(
-            IntPtr compiler, 
-            YR_COMPILER_CALLBACK_FUNC callback, 
+            IntPtr compiler,
+            YR_COMPILER_CALLBACK_FUNC callback,
             IntPtr user_data);
 
 
@@ -72,9 +72,9 @@ namespace dnYara.Interop
         ///user_data: void*
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_set_include_callback")]
         public static extern void yr_compiler_set_include_callback(
-            IntPtr compiler, 
-            YR_COMPILER_INCLUDE_CALLBACK_FUNC include_callback, 
-            YR_COMPILER_INCLUDE_FREE_FUNC include_free, 
+            IntPtr compiler,
+            YR_COMPILER_INCLUDE_CALLBACK_FUNC include_callback,
+            YR_COMPILER_INCLUDE_FREE_FUNC include_free,
             IntPtr user_data);
 
 
@@ -84,8 +84,8 @@ namespace dnYara.Interop
         ///user_data: void*
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_set_re_ast_callback")]
         public static extern void yr_compiler_set_re_ast_callback(
-            IntPtr compiler, 
-            YR_COMPILER_RE_AST_CALLBACK_FUNC re_ast_callback, 
+            IntPtr compiler,
+            YR_COMPILER_RE_AST_CALLBACK_FUNC re_ast_callback,
             IntPtr user_data);
 
 
@@ -104,8 +104,8 @@ namespace dnYara.Interop
         ///warning_threshold: unsigned char
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_load_atom_quality_table")]
         public static extern int yr_compiler_load_atom_quality_table(
-            IntPtr compiler, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string filename, 
+            IntPtr compiler,
+            [In, MarshalAs(UnmanagedType.LPStr)] string filename,
             byte warning_threshold);
 
 
@@ -116,9 +116,9 @@ namespace dnYara.Interop
         ///file_name: char*
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_add_file", SetLastError = false)]
         public static extern int yr_compiler_add_file(
-            IntPtr compilerPtr, 
+            IntPtr compilerPtr,
             IntPtr filePtr,
-            [In, MarshalAs(UnmanagedType.LPStr)] string namespace_, 
+            [In, MarshalAs(UnmanagedType.LPStr)] string namespace_,
             [In, MarshalAs(UnmanagedType.LPStr)] string file_name);
 
 
@@ -129,9 +129,9 @@ namespace dnYara.Interop
         ///file_name: char*
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_add_fd")]
         public static extern int yr_compiler_add_fd(
-            IntPtr compiler, 
-            IntPtr rules_fd, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string namespace_, 
+            IntPtr compiler,
+            IntPtr rules_fd,
+            [In, MarshalAs(UnmanagedType.LPStr)] string namespace_,
             [In, MarshalAs(UnmanagedType.LPStr)] string file_name);
 
 
@@ -141,8 +141,8 @@ namespace dnYara.Interop
         ///namespace_: char*
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_add_string")]
         public static extern int yr_compiler_add_string(
-            IntPtr compilerPtr, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string rules_string, 
+            IntPtr compilerPtr,
+            [In, MarshalAs(UnmanagedType.LPStr)] string rules_string,
             [In, MarshalAs(UnmanagedType.LPStr)] string namespace_);
 
 
@@ -163,12 +163,12 @@ namespace dnYara.Interop
         /// Return Type: int
         ///compiler: YR_COMPILER*
         ///identifier: char*
-        ///value: int
+        ///value: int64_t
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_define_integer_variable")]
-        public static extern int yr_compiler_define_integer_variable(
-            IntPtr compiler, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string identifier, 
-            int value);
+        public static extern YARA_ERROR yr_compiler_define_integer_variable(
+            IntPtr compiler,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
+            long value);
 
 
         /// Return Type: int
@@ -176,9 +176,9 @@ namespace dnYara.Interop
         ///identifier: char*
         ///value: int
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_define_boolean_variable")]
-        public static extern int yr_compiler_define_boolean_variable(
-            IntPtr compiler, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string identifier, 
+        public static extern YARA_ERROR yr_compiler_define_boolean_variable(
+            IntPtr compiler,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
             int value);
 
 
@@ -187,9 +187,9 @@ namespace dnYara.Interop
         ///identifier: char*
         ///value: double
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_define_float_variable")]
-        public static extern int yr_compiler_define_float_variable(
-            IntPtr compiler, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string identifier, 
+        public static extern YARA_ERROR yr_compiler_define_float_variable(
+            IntPtr compiler,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
             double value);
 
 
@@ -198,9 +198,9 @@ namespace dnYara.Interop
         ///identifier: char*
         ///value: char*
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_define_string_variable")]
-        public static extern int yr_compiler_define_string_variable(
-            IntPtr compiler, 
-            [In, MarshalAs(UnmanagedType.LPStr)] string identifier, 
+        public static extern YARA_ERROR yr_compiler_define_string_variable(
+            IntPtr compiler,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
             [In, MarshalAs(UnmanagedType.LPStr)] string value);
 
 
@@ -209,7 +209,7 @@ namespace dnYara.Interop
         ///rules: YR_RULES**
         [DllImport(YaraLibName, EntryPoint = "yr_compiler_get_rules")]
         public static extern YARA_ERROR yr_compiler_get_rules(
-            IntPtr compilerPtr, 
+            IntPtr compilerPtr,
             ref IntPtr rules);
 
 
@@ -226,7 +226,7 @@ namespace dnYara.Interop
         [DllImport(YaraLibName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void yr_finalize();
 
-        
+
         /// Return Type: void
         [DllImport(YaraLibName, EntryPoint = "yr_finalize_thread")]
         public static extern void yr_finalize_thread();
@@ -268,11 +268,11 @@ namespace dnYara.Interop
         public static extern YARA_ERROR yr_rules_scan_mem(
             IntPtr rulesPtr,
             IntPtr buffer,
-            ulong buffer_size, 
-            int flags, 
+            ulong buffer_size,
+            int flags,
             [MarshalAs(UnmanagedType.FunctionPtr)]
-            YR_CALLBACK_FUNC callback, 
-            IntPtr user_data, 
+            YR_CALLBACK_FUNC callback,
+            IntPtr user_data,
             int timeout);
 
         /// int yr_rules_save(YR_RULES* rules, const char* filename)
@@ -299,9 +299,9 @@ namespace dnYara.Interop
         [DllImport(YaraLibName, EntryPoint = "yr_rules_scan_proc")]
         public static extern YARA_ERROR yr_rules_scan_proc(
             IntPtr rules,
-            int pid, int flags, 
-            YR_CALLBACK_FUNC callback, 
-            IntPtr user_data, 
+            int pid, int flags,
+            YR_CALLBACK_FUNC callback,
+            IntPtr user_data,
             int timeout);
 
 
@@ -315,11 +315,123 @@ namespace dnYara.Interop
         [DllImport(YaraLibName, EntryPoint = "yr_rules_scan_file")]
         public static extern YARA_ERROR yr_rules_scan_file(
             IntPtr rules,
-            [In, MarshalAs(UnmanagedType.LPStr)] string filename, 
-            int flags, 
-            YR_CALLBACK_FUNC callback, 
-            IntPtr user_data, 
+            [In, MarshalAs(UnmanagedType.LPStr)] string filename,
+            int flags,
+            YR_CALLBACK_FUNC callback,
+            IntPtr user_data,
             int timeout);
+
+
+
+        /// Return Type: int
+        ///rules: YR_RULES*
+        ///scanner: YR_SCAN_CONTEXT**
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_create")]
+        public static extern YARA_ERROR yr_scanner_create(
+            IntPtr rules,
+            out IntPtr scanner);
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_destroy")]
+        public static extern YARA_ERROR yr_scanner_destroy(
+            IntPtr scanner);
+
+
+        /// Return Type: void
+        ///scanner: YR_SCAN_CONTEXT*
+        ///callback: YR_CALLBACK_FUNC
+        ///user_data: void*
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_set_callback")]
+        public static extern void yr_scanner_set_callback(
+            IntPtr scanner,
+            YR_CALLBACK_FUNC callback,
+            IntPtr user_data
+            );
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        ///timeout: int
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_set_timeout")]
+        public static extern void yr_scanner_set_timeout(
+            IntPtr scanner,
+            int timeout);
+
+
+        /// Return Type: void
+        ///scanner: YR_SCAN_CONTEXT*
+        ///flags: int
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_set_flags")]
+        public static extern void yr_scanner_set_flags(
+            IntPtr scanner,
+            int flags);
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        ///identifier: char*
+        ///value: long
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_define_integer_variable")]
+        public static extern YARA_ERROR yr_scanner_define_integer_variable(
+            IntPtr scanner,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
+            long value);
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        ///identifier: char*
+        ///value: int
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_define_boolean_variable")]
+        public static extern YARA_ERROR yr_scanner_define_boolean_variable(
+            IntPtr scanner,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
+            int value);
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        ///identifier: char*
+        ///value: double
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_define_float_variable")]
+        public static extern YARA_ERROR yr_scanner_define_float_variable(
+            IntPtr scanner,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
+            double value);
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        ///identifier: char*
+        ///value: char*
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_define_string_variable")]
+        public static extern YARA_ERROR yr_scanner_define_string_variable(
+            IntPtr scanner,
+            [In, MarshalAs(UnmanagedType.LPStr)] string identifier,
+            [In, MarshalAs(UnmanagedType.LPStr)] string value
+            );
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        ///buffer: const uint8_t*
+        ///buffer_size: size_t
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_scan_mem")]
+        public static extern YARA_ERROR yr_scanner_scan_mem(
+            IntPtr scanner,
+            IntPtr buffer,
+            ulong buffer_size);
+
+
+        /// Return Type: int
+        ///scanner: YR_SCAN_CONTEXT*
+        ///filename: char*
+        [DllImport(YaraLibName, EntryPoint = "yr_scanner_scan_file")]
+        public static extern YARA_ERROR yr_scanner_scan_file(
+            IntPtr scanner,
+            [In, MarshalAs(UnmanagedType.LPStr)] string filename);
 
     }
 }

--- a/dnYara/Compiler.cs
+++ b/dnYara/Compiler.cs
@@ -92,6 +92,50 @@ namespace dnYara
                 throw new CompilationException(compilationErrors);
         }
 
+        public void DeclareExternalStringVariable(string name, string defaultValue = "")
+        {
+            var errors = Methods.yr_compiler_define_string_variable(
+                compilerPtr,
+                name,
+                defaultValue);
+
+            if (errors != 0)
+                throw new InvalidDataException($"Error {errors} in DeclareExternalStringVariable '{name}'='{defaultValue}'");
+        }
+
+        public void DeclareExternalIntVariable(string name, long defaultValue = 0)
+        {
+            var errors = Methods.yr_scanner_define_integer_variable(
+                compilerPtr,
+                name,
+                defaultValue);
+
+            if (errors != 0)
+                throw new InvalidDataException($"Error {errors} in DeclareExternalIntVariable '{name}'={defaultValue}");
+        }
+
+        public void DeclareExternalFloatVariable(string name, double defaultValue = 0)
+        {
+            var errors = Methods.yr_scanner_define_float_variable(
+                compilerPtr,
+                name,
+                defaultValue);
+
+            if (errors != 0)
+                throw new InvalidDataException($"Error {errors} in DeclareExternalFloatVariable setting '{name}'={defaultValue}");
+        }
+
+        public void DeclareExternalBooleanVariable(string name, bool defaultValue = false)
+        {
+            var errors = Methods.yr_compiler_define_boolean_variable(
+                compilerPtr,
+                name,
+                defaultValue == true ? 1 : 0);
+
+            if (errors != 0)
+                throw new InvalidDataException($"Error {errors} in DeclareExternalBooleanVariable setting '{name}'={defaultValue}");
+        }
+
         public CompiledRules Compile()
         {
             IntPtr rulesPtr = new IntPtr();

--- a/dnYara/CustomScanner.cs
+++ b/dnYara/CustomScanner.cs
@@ -1,0 +1,252 @@
+﻿using dnYara.Interop;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace dnYara
+{
+    public class CustomScanner
+    {
+        private const int YR_TIMEOUT = 10000;
+
+        private IntPtr customScannerPtr = IntPtr.Zero;
+
+        public CustomScanner(CompiledRules rules, int flags = 0, int timeout = YR_TIMEOUT)
+        {
+            CreateNewScanner(rules, (YR_SCAN_FLAGS)flags, timeout);
+        }
+
+        ~CustomScanner()
+        {
+            if (customScannerPtr != IntPtr.Zero)
+            {
+                Methods.yr_scanner_destroy(customScannerPtr);
+            }
+        }
+
+
+        private void CreateNewScanner(CompiledRules rules, YR_SCAN_FLAGS flags, int timeout)
+        {
+            ErrorUtility.ThrowOnError(
+                Methods.yr_scanner_create(rules.BasePtr, out IntPtr newScanner));
+
+            customScannerPtr = newScanner;
+
+            SetFlags(flags);
+            SetTimeout(timeout);
+        }
+
+        public virtual void SetFlags(YR_SCAN_FLAGS flags) => Methods.yr_scanner_set_flags(customScannerPtr, (int)flags);
+        public virtual void SetTimeout(int timeout) => Methods.yr_scanner_set_timeout(customScannerPtr, timeout);
+
+        private bool TestAllVariablesUnique(ExternalVariables externalVariables, out string duplicatesListString)
+        {
+            duplicatesListString = "";
+
+            List<string> allKeys = externalVariables.StringVariables.Keys.ToList();
+            allKeys.AddRange(externalVariables.IntVariables.Keys.ToList());
+            allKeys.AddRange(externalVariables.FloatVariables.Keys.ToList());
+            allKeys.AddRange(externalVariables.BoolVariables.Keys.ToList());
+
+            var duplicates = allKeys.GroupBy(_ => _).Where(_ => _.Count() > 1).ToList();
+
+            if (duplicates.Count == 0) return true;
+
+            for (var i = 0; i < duplicates.Count; i++)
+            {
+                duplicatesListString += $"{duplicates[i].Key}";
+                if (i < (duplicates.Count - 1))
+                    duplicatesListString += ", ";
+            }
+
+            return false;
+        }
+
+        private void SetExternalVariables(ExternalVariables externalVariables)
+        {
+            if (!TestAllVariablesUnique(externalVariables, out string duplicates))
+            {
+                throw new InvalidDataException("Duplicate external variable names declared: " + duplicates);
+            }
+
+            foreach (KeyValuePair<string, string> variable in externalVariables.StringVariables)
+                ErrorUtility.ThrowOnError(
+                     Methods.yr_scanner_define_string_variable(customScannerPtr, variable.Key, variable.Value));
+
+            foreach (KeyValuePair<string, long> variable in externalVariables.IntVariables)
+                ErrorUtility.ThrowOnError(
+                    Methods.yr_scanner_define_integer_variable(customScannerPtr, variable.Key, variable.Value));
+
+            foreach (KeyValuePair<string, double> variable in externalVariables.FloatVariables)
+                ErrorUtility.ThrowOnError(
+                    Methods.yr_scanner_define_float_variable(customScannerPtr, variable.Key, variable.Value));
+
+            foreach (KeyValuePair<string, bool> variable in externalVariables.BoolVariables)
+                ErrorUtility.ThrowOnError(
+                    Methods.yr_scanner_define_boolean_variable(customScannerPtr, variable.Key, variable.Value == true ? 1 : 0));
+        }
+
+        //YARA doesnt allow deletion of variables, this cleans them us as much as practical but
+        //a new scanner should be created if it's imporant for them not to exist
+        private void ClearExternalVariables(ExternalVariables externalVariables)
+        {
+            foreach (KeyValuePair<string, string> variable in externalVariables.StringVariables)
+                ErrorUtility.ThrowOnError(
+                    Methods.yr_scanner_define_string_variable(customScannerPtr, variable.Key, String.Empty));
+
+            foreach (KeyValuePair<string, long> variable in externalVariables.IntVariables)
+                ErrorUtility.ThrowOnError(
+                    Methods.yr_scanner_define_integer_variable(customScannerPtr, variable.Key, long.MinValue));
+
+            foreach (KeyValuePair<string, double> variable in externalVariables.FloatVariables)
+                ErrorUtility.ThrowOnError(
+                    Methods.yr_scanner_define_float_variable(customScannerPtr, variable.Key, float.NegativeInfinity));
+
+            foreach (KeyValuePair<string, bool> variable in externalVariables.BoolVariables)
+                ErrorUtility.ThrowOnError(
+                    Methods.yr_scanner_define_boolean_variable(customScannerPtr, variable.Key, 0));
+        }
+
+
+        public virtual List<ScanResult> ScanFile(string path, ExternalVariables externalVariables)
+        {
+            if (customScannerPtr == IntPtr.Zero)
+                throw new NullReferenceException("Custom Scanner has not been initialised");
+
+            if (!File.Exists(path))
+                throw new FileNotFoundException(path);
+
+            SetExternalVariables(externalVariables);
+
+            YR_CALLBACK_FUNC scannerCallback = new YR_CALLBACK_FUNC(HandleMessage);
+            List<ScanResult> scanResults = new List<ScanResult>();
+            GCHandleHandler resultsHandle = new GCHandleHandler(scanResults);
+            Methods.yr_scanner_set_callback(customScannerPtr, scannerCallback, resultsHandle.GetPointer());
+
+            ErrorUtility.ThrowOnError(
+                Methods.yr_scanner_scan_file(
+                    customScannerPtr,
+                    path
+                    ));
+
+            ClearExternalVariables(externalVariables);
+
+            return scanResults;
+        }
+
+        public virtual List<ScanResult> ScanString(
+            string text,
+            ExternalVariables externalVariables,
+            Encoding encoding = null)
+        {
+            if (encoding == null)
+                encoding = Encoding.ASCII;
+
+            byte[] buffer = encoding.GetBytes(text);
+
+            return ScanMemory(ref buffer, externalVariables, YR_SCAN_FLAGS.None);
+        }
+
+        public virtual List<ScanResult> ScanStream(
+            Stream stream,
+            ExternalVariables externalVariables)
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                stream.CopyTo(ms);
+                byte[] buffer = ms.ToArray();
+
+                return ScanMemory(ref buffer, externalVariables, YR_SCAN_FLAGS.None);
+            }
+        }
+
+        public virtual List<ScanResult> ScanMemory(
+            ref byte[] buffer,
+            ExternalVariables externalVariables)
+        {
+            return ScanMemory(ref buffer, externalVariables, YR_SCAN_FLAGS.None);
+        }
+
+        public List<ScanResult> ScanMemory(
+            ref byte[] buffer,
+            ExternalVariables externalVariables,
+            YR_SCAN_FLAGS flags)
+        {
+            if (buffer.Length == 0)
+                return new List<ScanResult>();
+
+            return ScanMemory(ref buffer, buffer.Length, externalVariables, flags);
+        }
+
+        internal List<ScanResult> ScanMemory(
+            IntPtr buffer,
+            int length,
+            ExternalVariables externalVariables)
+        {
+            return ScanMemory(buffer, length, externalVariables, YR_SCAN_FLAGS.None);
+        }
+
+        internal List<ScanResult> ScanMemory(
+            IntPtr buffer,
+            int length,
+            ExternalVariables externalVariables,
+            YR_SCAN_FLAGS flags)
+        {
+            byte[] res = new byte[length - 1];
+            Marshal.Copy(buffer, res, 0, length);
+            return ScanMemory(ref res, length, externalVariables, flags);
+        }
+
+        public virtual List<ScanResult> ScanMemory(
+            ref byte[] buffer,
+            int length,
+            ExternalVariables externalVariables,
+            YR_SCAN_FLAGS flags)
+        {
+            YR_CALLBACK_FUNC scannerCallback = new YR_CALLBACK_FUNC(HandleMessage);
+            List<ScanResult> scanResults = new List<ScanResult>();
+            GCHandleHandler resultsHandle = new GCHandleHandler(scanResults);
+            Methods.yr_scanner_set_callback(customScannerPtr, scannerCallback, resultsHandle.GetPointer());
+
+            SetFlags(flags);
+            SetExternalVariables(externalVariables);
+
+            IntPtr btCpy = Marshal.AllocHGlobal(buffer.Length); ;
+            Marshal.Copy(buffer, 0, btCpy, (int)buffer.Length);
+
+            ErrorUtility.ThrowOnError(
+                Methods.yr_scanner_scan_mem(
+                    customScannerPtr,
+                    btCpy,
+                    (ulong)length
+                    ));
+
+            ClearExternalVariables(externalVariables);
+
+            return scanResults;
+        }
+
+        private YR_CALLBACK_RESULT HandleMessage(
+            IntPtr context,
+            int message,
+            IntPtr message_data,
+            IntPtr user_data)
+        {
+
+            if (message == Constants.CALLBACK_MSG_RULE_MATCHING)
+            {
+                var resultsHandle = GCHandle.FromIntPtr(user_data);
+                var results = (List<ScanResult>)resultsHandle.Target;
+
+                YR_RULE rule = Marshal.PtrToStructure<YR_RULE>(message_data);
+                YR_SCAN_CONTEXT scan_context = Marshal.PtrToStructure<YR_SCAN_CONTEXT>(context);
+                results.Add(new ScanResult(scan_context, rule));
+            }
+
+            return YR_CALLBACK_RESULT.Continue;
+        }
+    }
+}

--- a/dnYara/ExternalVariables.cs
+++ b/dnYara/ExternalVariables.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace dnYara
+{
+    /// <summary>
+    /// Data structure containing the different types of external variables passed to a custom scanner
+    /// </summary>
+    public class ExternalVariables
+    {
+        public Dictionary<string, string> StringVariables = new Dictionary<string, string>();
+
+        public Dictionary<string, long> IntVariables = new Dictionary<string, long>();
+
+        public Dictionary<string, double> FloatVariables = new Dictionary<string, double>();
+
+        public Dictionary<string, bool> BoolVariables = new Dictionary<string, bool>();
+
+        public void ClearAll()
+        {
+            StringVariables.Clear();
+            IntVariables.Clear();
+            FloatVariables.Clear();
+            BoolVariables.Clear();
+        }
+
+        public int CountAll()
+        {
+            return StringVariables.Count + IntVariables.Count + FloatVariables.Count + BoolVariables.Count;
+        }
+
+    }
+}


### PR DESCRIPTION
This PR deals with the external variable support TODO by creating a scanner with compiled rules and then calling it using external variables. It reuses most of the memory scanning code from the usual scanner and follows the same API format as the other externs so the actual changes are relatively minor.

It can be used like this:
`
        public static void ExternVariableTest()
        {
            string ruleString = "rule EXE_cloaked_as_TXT {\nmeta:\n\tdescription = \"Executable with TXT extension\"\n" +
                    "\tlicense = \"https://creativecommons.org/licenses/by-nc/4.0/\"\n" +
                    "\tauthor = \"Florian Roth\"\ncondition:\nuint16(0) == 0x5a4d and filename matches /\\.txt$/is}";

            byte[] fileContentsBuf = Encoding.ASCII.GetBytes("MZ_other_file_contents");

            using (YaraContext ctx = new YaraContext())
            {
                // Compile list of yara rules
                CompiledRules rules = null;
                using (var compiler = new Compiler())
                {
                    //compilation will fail if the variable used by a rule isn't declared at compile time
                    compiler.DeclareExternalStringVariable("filename");
                    compiler.AddRuleString(ruleString);
                    rules = compiler.Compile();
                }

                // Initialize the scanner
                var scanner = new CustomScanner(rules);

                //add string, long, double, bool external variables
                ExternalVariables externalVariables = new ExternalVariables();
                externalVariables.StringVariables.Add("filename", "ExecutableFile.txt");

                List<ScanResult> scanResults = scanner.ScanMemory(ref fileContentsBuf, externalVariables);
                Debug.Assert(scanResults.Count == 1);
        }
}
`