### PR TITLE
Enhance YaraContext management with Singleton pattern and exception handling

### DIFF
--- a/Samples/YaraInteractive/Program.cs
+++ b/Samples/YaraInteractive/Program.cs
@@ -7,26 +7,22 @@ namespace YaraInteractive
     {
         static void Main(string[] args)
         {
-            using (var ctx = new YaraContext())
+            Console.WriteLine("# Welcome to Yara Interactive Console...");
+
+            while (true)
             {
-                Console.WriteLine("# Welcome to Yara Interactive Console...");
+                Console.Write("> ");
 
-                while (true)
-                {
-                    Console.Write("> ");
+                string command = Console.ReadLine();
 
-                    string command = Console.ReadLine();
+                if (string.IsNullOrWhiteSpace(command))
+                    continue;
 
-                    if (string.IsNullOrWhiteSpace(command))
-                        continue;
+                bool isManagedCmd = CmdHandler.ExecuteCmd(command);
 
-                    bool isManagedCmd = CmdHandler.ExecuteCmd(command);
-
-                    if (!isManagedCmd)
-                        Console.WriteLine(":Err: Unknown command...");
-                }
+                if (!isManagedCmd)
+                    Console.WriteLine(":Err: Unknown command...");
             }
         }
-
     }
 }

--- a/UnitTests/dnYara.UnitTests/ScanTests.cs
+++ b/UnitTests/dnYara.UnitTests/ScanTests.cs
@@ -11,120 +11,106 @@ namespace dnYara.UnitTests
         [Fact]
         public void CheckStringMatchTest()
         {
-            // Initialize yara context
-            using (YaraContext ctx = new YaraContext())
+            // Compile yara rules
+            CompiledRules rules = null;
+
+            using (var compiler = new Compiler())
             {
-                // Compile yara rules
-                CompiledRules rules = null;
+                compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a}");
 
-                using (var compiler = new Compiler())
-                {
-                    compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a}");
+                rules = compiler.Compile();
+            }
 
-                    rules = compiler.Compile();
-                }
+            if (rules != null)
+            {
+                // Initialize the scanner
+                var scanner = new Scanner();
 
-                if (rules != null)
-                {
-                    // Initialize the scanner
-                    var scanner = new Scanner();
+                List<ScanResult> scanResult = scanner.ScanString("abcdefgjiklmnoprstuvwxyz", rules);
 
-                    List<ScanResult> scanResult = scanner.ScanString("abcdefgjiklmnoprstuvwxyz", rules);
-
-                    Assert.True(scanResult.Count > 0);
-                }
+                Assert.True(scanResult.Count > 0);
             }
         }
 
         [Fact]
         public void CheckStringNotMatchTest()
         {
-            // Initialize yara context
-            using (YaraContext ctx = new YaraContext())
+            // Compile yara rules
+            CompiledRules rules = null;
+
+            using (var compiler = new Compiler())
             {
-                // Compile yara rules
-                CompiledRules rules = null;
+                compiler.AddRuleString("rule foo: bar {strings: $a = \"nml\" condition: $a}");
 
-                using (var compiler = new Compiler())
-                {
-                    compiler.AddRuleString("rule foo: bar {strings: $a = \"nml\" condition: $a}");
+                rules = compiler.Compile();
+            }
 
-                    rules = compiler.Compile();
-                }
+            if (rules != null)
+            {
+                // Initialize the scanner
+                var scanner = new Scanner();
+                List<ScanResult> scanResult = scanner.ScanString("abcdefgjiklmnoprstuvwxyz", rules);
 
-                if (rules != null)
-                {
-                    // Initialize the scanner
-                    var scanner = new Scanner();
-                    List<ScanResult> scanResult = scanner.ScanString("abcdefgjiklmnoprstuvwxyz", rules);
-
-                    Assert.True(scanResult.Count == 0);
-                }
+                Assert.True(scanResult.Count == 0);
             }
         }
 
         [Fact]
         public void CheckMemoryMatchTest()
         {
-            // Initialize yara context
-            using (YaraContext ctx = new YaraContext())
+            // Compile yara rules
+            CompiledRules rules = null;
+
+            using (var compiler = new Compiler())
             {
-                // Compile yara rules
-                CompiledRules rules = null;
+                compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a}");
 
-                using (var compiler = new Compiler())
-                {
-                    compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a}");
-
-                    rules = compiler.Compile();
-                }
-
-                if (rules != null)
-                {
-                    // Initialize the scanner
-                    var scanner = new Scanner();
-
-                    Encoding encoding = Encoding.ASCII;
-
-                    byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
-
-                    List<ScanResult> scanResult = scanner.ScanMemory(ref buffer, rules);
-
-                    Assert.True(scanResult.Count > 0);
-                }
+                rules = compiler.Compile();
             }
+
+            if (rules != null)
+            {
+                // Initialize the scanner
+                var scanner = new Scanner();
+
+                Encoding encoding = Encoding.ASCII;
+
+                byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
+
+                List<ScanResult> scanResult = scanner.ScanMemory(ref buffer, rules);
+
+                Assert.True(scanResult.Count > 0);
+            }
+
         }
 
         [Fact]
         public void CheckMemoryNotMatchTest()
         {
-            // Initialize yara context
-            using (YaraContext ctx = new YaraContext())
+            // Compile yara rules
+            CompiledRules rules = null;
+
+            using (var compiler = new Compiler())
             {
-                // Compile yara rules
-                CompiledRules rules = null;
+                compiler.AddRuleString("rule foo: bar {strings: $a = \"nml\" condition: $a}");
 
-                using (var compiler = new Compiler())
-                {
-                    compiler.AddRuleString("rule foo: bar {strings: $a = \"nml\" condition: $a}");
-
-                    rules = compiler.Compile();
-                }
-
-                if (rules != null)
-                {
-                    // Initialize the scanner
-                    var scanner = new Scanner();
-
-                    Encoding encoding = Encoding.ASCII;
-
-                    byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
-
-                    List<ScanResult> scanResult = scanner.ScanMemory(ref buffer, rules);
-
-                    Assert.True(scanResult.Count == 0);
-                }
+                rules = compiler.Compile();
             }
+
+            if (rules != null)
+            {
+                // Initialize the scanner
+                var scanner = new Scanner();
+
+                Encoding encoding = Encoding.ASCII;
+
+                byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
+
+                List<ScanResult> scanResult = scanner.ScanMemory(ref buffer, rules);
+
+                Assert.True(scanResult.Count == 0);
+            }
+
         }
 
         [Fact]
@@ -141,71 +127,64 @@ namespace dnYara.UnitTests
                     $a
                 }";
 
-            // Initialize yara context
-            using (YaraContext ctx = new YaraContext())
+            // Compile yara rules
+            CompiledRules rules = null;
+
+            using (var compiler = new Compiler())
             {
-                // Compile yara rules
-                CompiledRules rules = null;
+                compiler.AddRuleString(ruleText);
 
-                using (var compiler = new Compiler())
-                {
-                    compiler.AddRuleString(ruleText);
-
-                    rules = compiler.Compile();
-                }
-
-                if (rules != null)
-                {
-                    var rule = rules.Rules.ToList()[0];
-                    Assert.NotEmpty(rules.Rules);
-                    Assert.Equal("foo", rule.Identifier);
-                    Assert.Equal("bar", rule.Tags[0]);
-                    Assert.Equal(true, rule.Metas["bool_meta"]);
-                    Assert.Equal((long)10, rule.Metas["int_meta"]);
-                    Assert.Equal("what a long, drawn-out thing this is!", rule.Metas["string_meta"]);
-                }
+                rules = compiler.Compile();
             }
+
+            if (rules != null)
+            {
+                var rule = rules.Rules.ToList()[0];
+                Assert.NotEmpty(rules.Rules);
+                Assert.Equal("foo", rule.Identifier);
+                Assert.Equal("bar", rule.Tags[0]);
+                Assert.Equal(true, rule.Metas["bool_meta"]);
+                Assert.Equal((long)10, rule.Metas["int_meta"]);
+                Assert.Equal("what a long, drawn-out thing this is!", rule.Metas["string_meta"]);
+            }
+
         }
 
         [Fact]
         public void CheckSaveLoadRuleTest()
         {
-            // Initialize yara context
-            using (YaraContext ctx = new YaraContext())
+            using (var compiler = new Compiler())
             {
-                using (var compiler = new Compiler())
-                {
 
-                    compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a}");
-                    CompiledRules compiledRules = compiler.Compile();
-                    Assert.True(compiledRules.RuleCount == 1);
+                compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a}");
+                CompiledRules compiledRules = compiler.Compile();
+                Assert.True(compiledRules.RuleCount == 1);
 
-                    Encoding encoding = Encoding.ASCII;
-                    byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
+                Encoding encoding = Encoding.ASCII;
+                byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
 
-                    // Initialize the scanner
-                    var scanner = new Scanner();
+                // Initialize the scanner
+                var scanner = new Scanner();
 
-                    List<ScanResult> compiledScanResults = scanner.ScanMemory(ref buffer, compiledRules);
-                    Assert.True(compiledScanResults.Count == 1);
-                    Assert.Equal("foo", compiledScanResults[0].MatchingRule.Identifier);
+                List<ScanResult> compiledScanResults = scanner.ScanMemory(ref buffer, compiledRules);
+                Assert.True(compiledScanResults.Count == 1);
+                Assert.Equal("foo", compiledScanResults[0].MatchingRule.Identifier);
 
 
-                    //save the rule to disk
-                    string tempfile = System.IO.Path.GetTempFileName();
-                    bool saved = compiledRules.Save(tempfile);
-                    Assert.True(saved);
+                //save the rule to disk
+                string tempfile = System.IO.Path.GetTempFileName();
+                bool saved = compiledRules.Save(tempfile);
+                Assert.True(saved);
 
-                    //load the saved rule to a new ruleset
-                    CompiledRules loadedRules = new CompiledRules(tempfile);
+                //load the saved rule to a new ruleset
+                CompiledRules loadedRules = new CompiledRules(tempfile);
 
-                    List<ScanResult> loadedScanResults = scanner.ScanMemory(ref buffer, loadedRules);
+                List<ScanResult> loadedScanResults = scanner.ScanMemory(ref buffer, loadedRules);
 
-                    Assert.True(loadedScanResults.Count == 1);
-                    Assert.Equal("foo", loadedScanResults[0].MatchingRule.Identifier);
+                Assert.True(loadedScanResults.Count == 1);
+                Assert.Equal("foo", loadedScanResults[0].MatchingRule.Identifier);
 
-                    System.IO.File.Delete(tempfile);
-                }
+                System.IO.File.Delete(tempfile);
             }
         }
 
@@ -213,40 +192,33 @@ namespace dnYara.UnitTests
         [Fact]
         public void CheckExternalVariableRuleTest()
         {
-            // Initialize yara context
-            using (YaraContext ctx = new YaraContext())
+            using (var compiler = new Compiler())
             {
-                using (var compiler = new Compiler())
-                {
-                    //must declare this or the compiler will complain it doesn't exist when a rule references it
-                    compiler.DeclareExternalStringVariable("filename");
+                //must declare this or the compiler will complain it doesn't exist when a rule references it
+                compiler.DeclareExternalStringVariable("filename");
 
-                    //declare rule with an external variable available
-                    compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a and filename matches /\\.txt$/is}");
-                    CompiledRules compiledRules = compiler.Compile();
+                //declare rule with an external variable available
+                compiler.AddRuleString("rule foo: bar {strings: $a = \"lmn\" condition: $a and filename matches /\\.txt$/is}");
+                CompiledRules compiledRules = compiler.Compile();
 
-                    Assert.True(compiledRules.RuleCount == 1);
+                Assert.True(compiledRules.RuleCount == 1);
 
-                    Encoding encoding = Encoding.ASCII;
-                    byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
+                Encoding encoding = Encoding.ASCII;
+                byte[] buffer = encoding.GetBytes("abcdefgjiklmnoprstuvwxyz");
 
-                    // Initialize a customscanner we can add variables to
-                    var scanner = new CustomScanner(compiledRules);
+                // Initialize a customscanner we can add variables to
+                var scanner = new CustomScanner(compiledRules);
 
-                    ExternalVariables externalVariables = new ExternalVariables();
-                    externalVariables.StringVariables.Add("filename", "Alphabet.txt");
+                ExternalVariables externalVariables = new ExternalVariables();
+                externalVariables.StringVariables.Add("filename", "Alphabet.txt");
 
-                    List<ScanResult> compiledScanResults = scanner.ScanMemory(ref buffer, externalVariables);
+                List<ScanResult> compiledScanResults = scanner.ScanMemory(ref buffer, externalVariables);
 
-                    Assert.True(compiledScanResults.Count == 1);
-                    Assert.Equal("foo", compiledScanResults[0].MatchingRule.Identifier);
+                Assert.True(compiledScanResults.Count == 1);
+                Assert.Equal("foo", compiledScanResults[0].MatchingRule.Identifier);
 
-                    //release before falling out of the yara context
-                    scanner.Release();                    
-                }
-
-
-
+                //release before falling out of the yara context
+                scanner.Release();
             }
         }
     }

--- a/dnYara/Compiler.cs
+++ b/dnYara/Compiler.cs
@@ -21,6 +21,8 @@ namespace dnYara
 
         public Compiler()
         {
+            YaraContext.Instance.EnsureInitialized();
+
             ErrorUtility.ThrowOnError(Methods.yr_compiler_create(out compilerPtr));
 
             compilationErrors = new List<string>();
@@ -49,6 +51,8 @@ namespace dnYara
 
         public void AddRuleFile(string path)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             compilationErrors.Clear();
 
             try
@@ -81,6 +85,8 @@ namespace dnYara
 
         public void AddRuleString(string rule)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             compilationErrors.Clear();
 
             var errors = Methods.yr_compiler_add_string(
@@ -94,6 +100,8 @@ namespace dnYara
 
         public void DeclareExternalStringVariable(string name, string defaultValue = "")
         {
+            YaraContext.Instance.EnsureInitialized();
+
             var errors = Methods.yr_compiler_define_string_variable(
                 compilerPtr,
                 name,
@@ -105,6 +113,8 @@ namespace dnYara
 
         public void DeclareExternalIntVariable(string name, long defaultValue = 0)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             var errors = Methods.yr_scanner_define_integer_variable(
                 compilerPtr,
                 name,
@@ -116,6 +126,8 @@ namespace dnYara
 
         public void DeclareExternalFloatVariable(string name, double defaultValue = 0)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             var errors = Methods.yr_scanner_define_float_variable(
                 compilerPtr,
                 name,
@@ -127,6 +139,8 @@ namespace dnYara
 
         public void DeclareExternalBooleanVariable(string name, bool defaultValue = false)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             var errors = Methods.yr_compiler_define_boolean_variable(
                 compilerPtr,
                 name,
@@ -138,6 +152,8 @@ namespace dnYara
 
         public CompiledRules Compile()
         {
+            YaraContext.Instance.EnsureInitialized();
+
             IntPtr rulesPtr = new IntPtr();
 
             ErrorUtility.ThrowOnError(
@@ -148,6 +164,8 @@ namespace dnYara
 
         public static CompiledRules CompileRulesFile(string path)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             Compiler yc = new Compiler();
             yc.AddRuleFile(path);
 
@@ -156,6 +174,8 @@ namespace dnYara
 
         public static CompiledRules CompileRulesString(string rule)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             Compiler yc = new Compiler();
             yc.AddRuleString(rule);
 

--- a/dnYara/CustomScanner.cs
+++ b/dnYara/CustomScanner.cs
@@ -30,12 +30,16 @@ namespace dnYara
         //must be called before the context is destroyed (ie: falling out of a using())
         public void Release()
         {
+            YaraContext.Instance.EnsureInitialized();
+
             Methods.yr_scanner_destroy(customScannerPtr);
             customScannerPtr = IntPtr.Zero;
         }
 
         private void CreateNewScanner(CompiledRules rules, YR_SCAN_FLAGS flags, int timeout)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             ErrorUtility.ThrowOnError(
                 Methods.yr_scanner_create(rules.BasePtr, out IntPtr newScanner));
 
@@ -45,8 +49,17 @@ namespace dnYara
             SetTimeout(timeout);
         }
 
-        public virtual void SetFlags(YR_SCAN_FLAGS flags) => Methods.yr_scanner_set_flags(customScannerPtr, (int)flags);
-        public virtual void SetTimeout(int timeout) => Methods.yr_scanner_set_timeout(customScannerPtr, timeout);
+        public virtual void SetFlags(YR_SCAN_FLAGS flags)
+        {
+            YaraContext.Instance.EnsureInitialized();
+            Methods.yr_scanner_set_flags(customScannerPtr, (int)flags);
+        }
+
+        public virtual void SetTimeout(int timeout)
+        {
+            YaraContext.Instance.EnsureInitialized();
+            Methods.yr_scanner_set_timeout(customScannerPtr, timeout);
+        }
 
         private bool TestAllVariablesUnique(ExternalVariables externalVariables, out string duplicatesListString)
         {
@@ -73,6 +86,8 @@ namespace dnYara
 
         private void SetExternalVariables(ExternalVariables externalVariables)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             if (!TestAllVariablesUnique(externalVariables, out string duplicates))
             {
                 throw new InvalidDataException("Duplicate external variable names declared: " + duplicates);
@@ -99,6 +114,8 @@ namespace dnYara
         //a new scanner should be created if it's imporant for them not to exist
         private void ClearExternalVariables(ExternalVariables externalVariables)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             foreach (KeyValuePair<string, string> variable in externalVariables.StringVariables)
                 ErrorUtility.ThrowOnError(
                     Methods.yr_scanner_define_string_variable(customScannerPtr, variable.Key, String.Empty));
@@ -119,6 +136,8 @@ namespace dnYara
 
         public virtual List<ScanResult> ScanFile(string path, ExternalVariables externalVariables)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             if (customScannerPtr == IntPtr.Zero)
                 throw new NullReferenceException("Custom Scanner has not been initialised");
 
@@ -212,6 +231,8 @@ namespace dnYara
             ExternalVariables externalVariables,
             YR_SCAN_FLAGS flags)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             YR_CALLBACK_FUNC scannerCallback = new YR_CALLBACK_FUNC(HandleMessage);
             List<ScanResult> scanResults = new List<ScanResult>();
             GCHandleHandler resultsHandle = new GCHandleHandler(scanResults);

--- a/dnYara/Exceptions/YaraContextNotInitializedException.cs
+++ b/dnYara/Exceptions/YaraContextNotInitializedException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace dnYara.Exceptions
+{
+    public class YaraContextNotInitializedException : InvalidOperationException
+    {
+        public YaraContextNotInitializedException()
+            : base("YaraContext has been cleaned up.")
+        {
+        }
+    }
+}

--- a/dnYara/ScanResult.cs
+++ b/dnYara/ScanResult.cs
@@ -5,7 +5,6 @@ using dnYara.Interop;
 
 namespace dnYara
 {
-
     public class ScanResult
     {
         public Rule MatchingRule;

--- a/dnYara/Scanner.cs
+++ b/dnYara/Scanner.cs
@@ -15,6 +15,7 @@ namespace dnYara
 
         public Scanner()
         {
+            YaraContext.Instance.EnsureInitialized();
             callbackPtr = new YR_CALLBACK_FUNC(HandleMessage);
         }
 
@@ -30,6 +31,8 @@ namespace dnYara
         {
             if (!File.Exists(path))
                 throw new FileNotFoundException(path);
+
+            YaraContext.Instance.EnsureInitialized();
 
             var results = new List<ScanResult>();
             var nativePath = path;
@@ -60,6 +63,8 @@ namespace dnYara
             CompiledRules rules,
             YR_SCAN_FLAGS flags)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             var results = new List<ScanResult>();
             GCHandleHandler resultsHandle = new GCHandleHandler(results);
 
@@ -144,6 +149,8 @@ namespace dnYara
             CompiledRules rules,
             YR_SCAN_FLAGS flags)
         {
+            YaraContext.Instance.EnsureInitialized();
+
             var results = new List<ScanResult>();
             GCHandleHandler resultsHandle = new GCHandleHandler(results);
 

--- a/dnYara/YaraContext.cs
+++ b/dnYara/YaraContext.cs
@@ -6,23 +6,50 @@ namespace dnYara
     /// <summary>
     /// RAII wrapper for Yara context, must be used with 'using' keyword. 
     /// </summary>
-    public sealed class YaraContext 
-        : IDisposable
+    public sealed class YaraContext
     {
-        public YaraContext()
+        private static readonly Lazy<YaraContext> lazy =
+            new Lazy<YaraContext>(() => new YaraContext());
+
+        public static YaraContext Instance { get { return lazy.Value; } }
+
+        private bool isCleanedUp = false;
+
+        private YaraContext()
         {
             ErrorUtility.ThrowOnError(Methods.yr_initialize());
         }
 
         ~YaraContext()
         {
-            Dispose();
+            Cleanup();
         }
 
-        public void Dispose()
+        public void Cleanup()
         {
-            Methods.yr_finalize();
+            if (!isCleanedUp)
+            {
+                Methods.yr_finalize();
+                isCleanedUp = true;
+            }
+        }
+
+        public void EnsureInitialized()
+        {
+            if (isCleanedUp)
+            {
+                throw new InvalidOperationException("YaraContext has been cleaned up.");
+            }
+        }
+
+        public void Reinitialize()
+        {
+            if (isCleanedUp)
+            {
+                ErrorUtility.ThrowOnError(Methods.yr_initialize());
+                isCleanedUp = false;
+            }
         }
     }
-    
+
 }

--- a/dnYara/dnYara.csproj
+++ b/dnYara/dnYara.csproj
@@ -4,10 +4,10 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Sylvain B. for Airbus CERT</Authors>
+    <Authors>Sylvain Bruyere, Airbus CERT</Authors>
     <Company>Airbus CERT</Company>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <AssemblyVersion>2.2.0.0</AssemblyVersion>
+    <FileVersion>2.2.0.0</FileVersion>
     <Description>dnYara (for Yara v4.0.0 to v4.1.1) is a .Net Standard wrapper for the native Yara library. It lets you use all the features of Yara that the native C library exposes !
 
 It is built in C# / .Net Standard to ensure compatibility with a maximum of .Net frameworks, and to be cross-platform.
@@ -18,17 +18,25 @@ You can also compile the library yourself for your platform with cmake (instruct
     <PackageProjectUrl>https://github.com/airbus-cert/dnYara</PackageProjectUrl>
     <RepositoryUrl>https://github.com/airbus-cert/dnYara</RepositoryUrl>
     <PackageTags>yara, DFIR, detection, malware</PackageTags>
-    <Version>2.1.0.0</Version>
+    <Version>2.2.0.0</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageId>dnYara</PackageId>
     <Product>dnYara (for Yara 4.0.0 to 4.1.1)</Product>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>TRACE;</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />


### PR DESCRIPTION
## Purpose
This PR addresses an issue related to memory access errors in the dnYara library when used in a C# environment. These errors were due to premature garbage collection of the YaraContext ctx object.

This address issue https://github.com/airbus-cert/dnYara/issues/10.

## Why
The issue arose because the YaraContext object was being collected by the .NET garbage collector before its usage was completed, especially in the Release build where garbage collection can be more aggressive.

## What was changed
The YaraContext implementation was restructured to use the Singleton pattern, ensuring a single instance of the Yara context across the application. This change allows the application to maintain a reference to the context, preventing it from being prematurely collected by the GC. Additionally, an EnsureInitialized method was introduced to throw an exception if the context was cleaned up before a native Yara function was called. A Reinitialize method was also added to reopen the Yara context if it has been cleaned up.

## Changes made:

- Implemented Singleton pattern in YaraContext.
- Added EnsureInitialized method to YaraContext.
- Added Reinitialize method to YaraContext.

## Mentions
Special thanks to @lld1995 for giving more context to this issue.